### PR TITLE
bugfixes relating to Widget extras reorganization

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -8,7 +8,7 @@
 'use-strict';
 
 import {
-  Widget, attachWidget
+  Widget
 } from 'phosphor-widget';
 
 import {
@@ -72,7 +72,7 @@ function main(): void {
   panel.tabify(g2, g3);
   panel.tabify(g2, b3);
 
-  attachWidget(panel, document.body);
+  Widget.attach(panel, document.body);
 
   window.onresize = () => panel.update();
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "phosphor-splitpanel": "^0.9.8",
     "phosphor-stackedpanel": "^0.9.5",
     "phosphor-tabs": "^0.9.7",
-    "phosphor-widget": "^0.9.11"
+    "phosphor-widget": "^0.9.13"
   },
   "devDependencies": {
     "browserify": "^11.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import {
 } from 'phosphor-disposable';
 
 import {
-  overrideCursor
+  boxSizing, overrideCursor
 } from 'phosphor-domutil';
 
 import {
@@ -771,7 +771,7 @@ class DockPanel extends BoxPanel {
     var left: number;
     var width: number;
     var height: number;
-    var box = this.boxSizing;
+    var box = boxSizing(this.node);
     var rect = this.node.getBoundingClientRect();
 
     // Compute the overlay geometry based on the dock zone.


### PR DESCRIPTION
Since I'm going to be using DockPanel as the main droppable, I wanted to move example code off of SplitPanel and into this repo when I noticed these changes have not yet been made.